### PR TITLE
Update link for !includeurl in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ At the top of your PlantUML model you need to include the `EIP-PlantUML.puml` fi
 If you want to include the most recent version of the `EIP-PlantUML.puml` file, you can alternatively use 
 
 ```c#
-!includeurl https://raw.githubusercontent.com/aheil/EIP-PlantUML/master/dist/EIP-PlantUML.puml
+!includeurl https://raw.githubusercontent.com/plantuml-stdlib/EIP-PlantUML/main/dist/EIP-PlantUML.puml
 ```
 
 to link to the latest version available in the master repository.


### PR DESCRIPTION
The link inside the README was pointing to an older version from the master branch under the /aheil namespace.